### PR TITLE
Only setup score once

### DIFF
--- a/game/src/score.rs
+++ b/game/src/score.rs
@@ -29,11 +29,11 @@ fn add_score(
     }
 }
 
-fn setup_score(
-    mut commands: Commands
-) {
-    commands.spawn((Score {
-        history: vec!(),
-    }, Name::new("Score")));
+fn setup_score(mut commands: Commands, mut score_q: Query<&mut Score>) {
+    if let Ok(mut score) = score_q.get_single_mut() {
+        score.history.clear();
+    } else {
+        commands.spawn((Score { history: vec![] }, Name::new("Score")));
+    }
 }
 


### PR DESCRIPTION
If there are multiple instances, score_q.get_single_mut() doesn't return any.

Therefore, if you started the game more than once, the score was always shown as 0.

So, instead of spawning a second instance, just clear out the existing one.

Not that I now close to nothing about bevy or ECS in general. So this might not be the right way to fix it. But it seems to work :-)